### PR TITLE
feat: 메인페이지 설정 버튼 추가

### DIFF
--- a/money_log/src/components/BaseHeader.vue
+++ b/money_log/src/components/BaseHeader.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script setup>
-import { useRouter } from 'vue-router';
+import { useRouter } from "vue-router";
 
 const router = useRouter();
 
@@ -36,7 +36,7 @@ const goBack = () => {
 };
 
 const goHome = () => {
-  router.push('/');
+  router.push("/");
 };
 
 const goSettings = () => {

--- a/money_log/src/components/CustomCalendar.vue
+++ b/money_log/src/components/CustomCalendar.vue
@@ -157,4 +157,12 @@ const goToMoneyPage = () => {
   justify-content: center;
   align-items: center;
 }
+
+:deep(.vc-title-wrapper),
+:deep(.vc-arrows),
+:deep(.vc-title),
+:deep(.vc-arrow) {
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
 </style>

--- a/money_log/src/components/DailyMoneyLog/DailyMoneyLog.vue
+++ b/money_log/src/components/DailyMoneyLog/DailyMoneyLog.vue
@@ -27,7 +27,7 @@ const handleStartClick = () => {
   max-width: 362px;
   min-width: 362px;
   height: 130px;
-  margin: 32px auto 16px auto;
+  margin: 28px auto 16px auto;
   box-sizing: border-box;
 }
 

--- a/money_log/src/components/MonthlySummary.vue
+++ b/money_log/src/components/MonthlySummary.vue
@@ -84,15 +84,13 @@ function formatNumber(num) {
   height: 18px;
 }
 
-/* ✅ 텍스트: 제목 */
 .summary-title {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
   color: #0b570e;
   text-align: center;
 }
 
-/* ✅ 수입/지출 행 */
 .amount-row {
   display: flex;
   justify-content: center;
@@ -112,7 +110,7 @@ function formatNumber(num) {
 }
 
 .total {
-  font-size: 13px;
+  font-size: 15px;
   font-weight: bold;
   color: #0b570e;
   text-align: center;

--- a/money_log/src/pages/MainPage.vue
+++ b/money_log/src/pages/MainPage.vue
@@ -1,21 +1,25 @@
 <script setup>
-import { ref, onMounted } from 'vue';
-import DailyMoneyLog from '@/components/DailyMoneyLog/DailyMoneyLog.vue';
-import CustomCalendar from '@/components/CustomCalendar.vue';
-import MonthlySummary from '@/components/MonthlySummary.vue';
-import AddMoney from '@/pages/AddMoney.vue';
+import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router"; // ✅ 추가
 
-const nickname = ref('');
+import DailyMoneyLog from "@/components/DailyMoneyLog/DailyMoneyLog.vue";
+import CustomCalendar from "@/components/CustomCalendar.vue";
+import MonthlySummary from "@/components/MonthlySummary.vue";
+import AddMoney from "@/pages/AddMoney.vue";
+
+const nickname = ref("");
 const isModalOpen = ref(false);
+const isSettingsOpen = ref(false);
+const router = useRouter(); // ✅ 라우터 인스턴스 생성
 
 onMounted(async () => {
   try {
-    const response = await fetch('http://localhost:3000/user');
-    if (!response.ok) throw new Error('닉네임 로딩 실패');
+    const response = await fetch("http://localhost:3000/user");
+    if (!response.ok) throw new Error("닉네임 로딩 실패");
     const data = await response.json();
     nickname.value = data.nickname;
   } catch (error) {
-    console.error('에러:', error);
+    console.error("에러:", error);
   }
 });
 
@@ -25,32 +29,144 @@ const openAddMoneyModal = () => {
 const closeAddMoneyModal = () => {
   isModalOpen.value = false;
 };
+
+const openSettings = () => {
+  isSettingsOpen.value = true;
+};
+const closeSettings = () => {
+  isSettingsOpen.value = false;
+};
+
+// ✅ 프로필 설정 페이지 이동
+const goToProfileEdit = () => {
+  router.push("/UserProfileEdit");
+};
 </script>
 
 <template>
   <div class="main-page">
-    <div class="nickname-title">{{ nickname }}'s Log</div>
+    <div class="nickname-header">
+      <div class="nickname-title">{{ nickname }}'s Log</div>
+      <img
+        src="@/assets/images/setting.png"
+        alt="설정"
+        class="settings-icon"
+        @click="openSettings"
+      />
+    </div>
+
     <DailyMoneyLog @start="openAddMoneyModal" />
     <CustomCalendar />
     <MonthlySummary />
     <AddMoney :show="isModalOpen" @close="closeAddMoneyModal" />
+    <div
+      v-if="isSettingsOpen"
+      class="settings-overlay"
+      @click.self="closeSettings"
+    >
+      <div class="settings-panel">
+        <h2 class="settings-title">Setting Log</h2>
+        <div class="setting-item" @click="goToProfileEdit">
+          <span class="icon">⚙️</span>
+          <span class="label">프로필 설정</span>
+          <span class="arrow">&gt;</span>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .main-page {
   background-color: #f1f1e8;
-  min-height: 100vh;
+  min-height: 100%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   padding-top: 56px;
   gap: 18px;
+  position: relative;
+  overflow: hidden;
+}
+
+.nickname-header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  position: relative;
 }
 
 .nickname-title {
+  font-size: 25px;
+  font-weight: bold;
+  color: #0b570e;
+  text-align: center;
+  margin-top: 15px;
+}
+
+.settings-icon {
+  position: absolute;
+  top: -22px;
+  right: 24px;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+}
+
+.settings-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(74, 71, 71, 0.6);
+  z-index: 1000;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.settings-panel {
+  background-color: white;
+  width: 70%;
+  height: 100%;
+  padding: 24px 16px;
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-title {
   font-size: 23px;
   font-weight: bold;
   color: #0b570e;
+  margin-bottom: 24px;
+}
+
+.setting-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #dedcdc;
+  padding: 12px 0;
+  cursor: pointer;
+}
+
+.setting-item .icon {
+  font-size: 18px;
+  margin-right: 8px;
+}
+
+.setting-item .label {
+  flex-grow: 1;
+  color: #0b570e;
+  font-weight: 600;
+  font-size: 19px;
+}
+
+.setting-item .arrow {
+  font-size: 18px;
+  color: #aaa;
 }
 </style>


### PR DESCRIPTION
## 🔗 반영 브랜치
(#30) feat/MainModal -> dev

## 📝 작업 내용
> 관련 파일 (`MainPage.vue`)
- `MainPage.vue`에 오른쪽 슬라이드 설정 패널 구현
- 설정 아이콘 클릭 시 배경 투명 오버레이`(rgba(74, 71, 71, 0.6))` 적용
    - 설정 패널은 전체 화면의 70% 너비로 오른쪽에서 슬라이드 형태로 표시
- 닉네임 아래 위치의 설정 아이콘 클릭 시 패널 열림, 배경 클릭 시 닫힘
- "프로필 설정" 항목 클릭 시 `/UserProfileEdit` 페이지로 라우팅 이동 처리

### 📸 스크린샷 (선택)
![스크린샷 2025-04-10 오전 12 54 35](https://github.com/user-attachments/assets/d8302379-abf7-4069-9d99-eee523aa980e)

