### PR TITLE
feat: money log db 연결

### DIFF
--- a/money_log/src/pages/AddMoney.vue
+++ b/money_log/src/pages/AddMoney.vue
@@ -1,35 +1,35 @@
 <script setup>
-import { ref, onMounted, computed } from 'vue';
-import { useMoneyStore } from '../stores/money';
-import '../assets/modal.css';
+import { ref } from "vue";
+import { useMoneyStore } from "../stores/money";
+import "../assets/modal.css";
 
 const props = defineProps({
   show: Boolean,
 });
-const emit = defineEmits(['close']);
-const closeModal = () => emit('close');
+const emit = defineEmits(["close"]);
+const closeModal = () => emit("close");
 
 const moneyStore = useMoneyStore();
 const isModalOpen = ref(false);
 const openModal = () => {
   isModalOpen.value = true;
-  console.log('✅ 모달 열림!'); // 콘솔 확인용
+  console.log("✅ 모달 열림!"); // 콘솔 확인용
 };
 
 const now = new Date();
-const hh = String(now.getHours()).padStart(2, '0');
-const mm = String(now.getMinutes()).padStart(2, '0');
+const hh = String(now.getHours()).padStart(2, "0");
+const mm = String(now.getMinutes()).padStart(2, "0");
 
-const day = ref('');
-const month = ref('');
-const year = ref('2025');
-const date = `${year.value}-${String(month.value).padStart(2, '0')}-${String(
+const day = ref("");
+const month = ref("");
+const year = ref("2025");
+const date = `${year.value}-${String(month.value).padStart(2, "0")}-${String(
   day.value
-).padStart(2, '0')}T${hh}:${mm}:00`;
+).padStart(2, "0")}T${hh}:${mm}:00`;
 
-const modalCategory = ref('');
-const modalAmount = ref('');
-const modalContent = ref('');
+const modalCategory = ref("");
+const modalAmount = ref("");
+const modalContent = ref("");
 
 const submitModal = async () => {
   if (
@@ -38,18 +38,18 @@ const submitModal = async () => {
     !modalAmount.value ||
     !modalCategory.value
   ) {
-    alert('모든 값을 입력해 주세요!');
+    alert("모든 값을 입력해 주세요!");
     return;
   }
 
   // 현재 시간 반영
   const now = new Date();
-  const hh = String(now.getHours()).padStart(2, '0');
-  const mm = String(now.getMinutes()).padStart(2, '0');
+  const hh = String(now.getHours()).padStart(2, "0");
+  const mm = String(now.getMinutes()).padStart(2, "0");
 
-  const date = `${year.value}-${String(month.value).padStart(2, '0')}-${String(
+  const date = `${year.value}-${String(month.value).padStart(2, "0")}-${String(
     day.value
-  ).padStart(2, '0')}T${hh}:${mm}:00`;
+  ).padStart(2, "0")}T${hh}:${mm}:00`;
 
   const newItem = {
     date,
@@ -63,11 +63,11 @@ const submitModal = async () => {
   closeModal();
 
   // 입력 초기화
-  day.value = '';
-  month.value = '';
-  modalCategory.value = '';
-  modalAmount.value = '';
-  modalContent.value = '';
+  day.value = "";
+  month.value = "";
+  modalCategory.value = "";
+  modalAmount.value = "";
+  modalContent.value = "";
 };
 </script>
 

--- a/money_log/src/stores/money.js
+++ b/money_log/src/stores/money.js
@@ -1,8 +1,8 @@
-import { defineStore } from 'pinia';
-import { ref, computed } from 'vue';
-import axios from 'axios';
+import { defineStore } from "pinia";
+import { ref, computed } from "vue";
+import axios from "axios";
 
-export const useMoneyStore = defineStore('money', () => {
+export const useMoneyStore = defineStore("money", () => {
   const moneyList = ref([]);
   const isLoading = ref(false);
   const error = ref(null);
@@ -18,29 +18,28 @@ export const useMoneyStore = defineStore('money', () => {
     isLoading.value = true;
     resetError();
     try {
-      const res = await axios.get('/api/money', { params });
+      const res = await axios.get("/api/money", { params });
       moneyList.value = res.data;
     } catch (err) {
-      error.value = '가계부 데이터를 불러오지 못했어요.';
-      console.error('🚨 fetch 에러:', err);
+      error.value = "가계부 데이터를 불러오지 못했어요.";
+      console.error("🚨 fetch 에러:", err);
     } finally {
       isLoading.value = false;
     }
   };
   // 고정 지출 데이터 가져오기
   const fetchPeriodicExpenses = async () => {
-    const res = await axios.get('/api/periodicExpense');
+    const res = await axios.get("/api/periodicExpense");
     periodicExpenseList.value = res.data;
   };
 
-  // action: 항목 추가
   const addMoneyLog = async (newItem) => {
     resetError();
     try {
-      const res = await axios.post('/api/money', newItem);
-      moneyList.value.push(res.data);
+      await axios.post("/api/money", newItem);
+      await fetchMoneyLogs();
     } catch (err) {
-      error.value = '항목 추가에 실패했어요.';
+      error.value = "항목 추가에 실패했어요.";
     }
   };
 
@@ -51,7 +50,7 @@ export const useMoneyStore = defineStore('money', () => {
       await axios.delete(`/api/money/${id}`);
       moneyList.value = moneyList.value.filter((item) => item.id !== id);
     } catch (err) {
-      error.value = '삭제 실패했어요.';
+      error.value = "삭제 실패했어요.";
     }
   };
 
@@ -67,16 +66,16 @@ export const useMoneyStore = defineStore('money', () => {
         console.warn(`❗수정하려는 항목(id: ${id})을 찾을 수 없습니다.`);
       }
     } catch (err) {
-      error.value = '수정에 실패했어요.';
+      error.value = "수정에 실패했어요.";
     }
   };
   // 고정 지출 추가 함수
   const addPeriodicExpense = async (newItem) => {
     try {
-      const res = await axios.post('/api/periodicExpense', newItem);
+      const res = await axios.post("/api/periodicExpense", newItem);
       periodicExpenseList.value.push(res.data);
     } catch (err) {
-      console.error('❌ 고정 지출 추가 실패:', err);
+      console.error("❌ 고정 지출 추가 실패:", err);
     }
   };
   // 고정 지출 삭제 함수
@@ -87,7 +86,7 @@ export const useMoneyStore = defineStore('money', () => {
         (item) => item.id !== id
       );
     } catch (err) {
-      console.error('❌ 고정 지출 삭제 실패:', err);
+      console.error("❌ 고정 지출 삭제 실패:", err);
     }
   };
 
@@ -103,10 +102,10 @@ export const useMoneyStore = defineStore('money', () => {
   const getMonthlySummary = (year, month) => {
     const logs = getLogsByMonth(year, month);
     const income = logs
-      .filter((i) => i.category === 'income')
+      .filter((i) => i.category === "income")
       .reduce((sum, cur) => sum + cur.amount, 0);
     const expense = logs
-      .filter((i) => i.category === 'expense')
+      .filter((i) => i.category === "expense")
       .reduce((sum, cur) => sum + cur.amount, 0);
     return {
       income,


### PR DESCRIPTION
## 🔗 반영 브랜치
(#40) feature/MainServer -> main 

## 📝 작업 내용
### 사용자가 `AddMoney.vue` 모달을 통해 입력한 수입/지출 데이터를 `json-server`의` /money DB`에 정상적으로 반영하도록 연동 작업을 완료했습니다.
- 사용자가 날짜, 카테고리, 금액, 내용을 입력 후 Submit 버튼 클릭 시
    - `useMoneyStore()`를 통해 `addMoneyLog()` 호출
    - POST 요청으로 DB(money 배열)에 새 데이터 추가
- 추가 후 리스트 갱신을 위해 `fetchMoneyLogs()`호출
- 입력 완료 시 입력값 초기화 및 모달 닫힘 처리

### 📸 스크린샷 (선택)
- 가장 마지막 부분에 입력한 부분 Update 되는 거 확인했습니다.
![스크린샷 2025-04-10 오전 10 16 20](https://github.com/user-attachments/assets/bdae6ff2-10ca-496a-a17c-5770eb3fbb91)
