### PR TITLE
feat: Spending 페이지에 설정 패널 연동 및 위치 조정

### DIFF
--- a/money_log/db.json
+++ b/money_log/db.json
@@ -1,57 +1,38 @@
 {
-  "user": [
-    {
-      "nickname": "dfsfd",
-      "id": "1"
-    },
-    {
-      "nickname": "dfsfd",
-      "id": "2"
-    },
-    {
-      "nickname": "dfsfd",
-      "id": "3"
-    },
-    {
-      "id": "8b74",
-      "nickname": "안녕"
-    },
-    {
-      "id": "c675",
-      "nickname": "둥"
-    }
-  ],
+  "user": {
+    "nickname": "옌"
+  },
   "money": [
     {
-      "id": "1",
+      "id": 1,
       "date": "2025-04-01T08:00:00",
       "category": "income",
       "content": "월급",
       "amount": 2500000
     },
     {
-      "id": "2",
+      "id": 2,
       "date": "2025-04-01T12:32:00",
       "category": "expense",
       "content": "식비",
       "amount": 12000
     },
     {
-      "id": "3",
+      "id": 3,
       "date": "2025-04-02T11:11:23",
       "category": "expense",
       "content": "교통비",
       "amount": 1400
     },
     {
-      "id": "4",
+      "id": 4,
       "date": "2025-04-03T22:27:27",
       "category": "expense",
       "content": "유흥",
       "amount": 43000
     },
     {
-      "id": "5",
+      "id": 5,
       "date": "2025-04-03T23:23:23",
       "category": "income",
       "content": "용돈",
@@ -59,7 +40,7 @@
       "memo": "부모님 용돈"
     },
     {
-      "id": "6",
+      "id": 6,
       "date": "2025-04-04T10:00:00",
       "category": "expense",
       "content": "공과금",
@@ -70,91 +51,98 @@
       "category": "income",
       "content": "주움",
       "amount": 5000,
-      "id": "7"
+      "id": 7
     },
     {
       "date": "2025-04-02T14:35:00",
       "category": "income",
       "content": "용돈",
       "amount": 50000,
-      "id": "8"
+      "id": 8
     },
     {
       "date": "2025-04-01T15:51:00",
       "category": "expense",
       "content": "돌려줌",
       "amount": 5000,
-      "id": "9"
+      "id": 9
+    },
+    {
+      "date": "2025-12-02T10:07:00",
+      "category": "income",
+      "content": "예은 테스트 ",
+      "amount": 12000,
+      "id": 10
     }
   ],
   "incomeCategory": [
     {
-      "id": "1",
+      "id": 1,
       "name": "월급"
     },
     {
-      "id": "2",
+      "id": 2,
       "name": "용돈"
     },
     {
-      "id": "3",
+      "id": 3,
       "name": "이자"
     },
     {
-      "id": "4",
+      "id": 4,
       "name": "기타 수입"
     }
   ],
   "expenseCategory": [
     {
-      "id": "1",
+      "id": 1,
       "name": "식비"
     },
     {
-      "id": "2",
+      "id": 2,
       "name": "교통비"
     },
     {
-      "id": "3",
+      "id": 3,
       "name": "유흥"
     },
     {
-      "id": "4",
+      "id": 4,
       "name": "공과금"
     },
     {
-      "id": "5",
+      "id": 5,
       "name": "쇼핑"
     },
     {
-      "id": "6",
+      "id": 6,
       "name": "의료비"
     }
   ],
   "periodicExpense": [
     {
-      "id": "1",
+      "id": 1,
       "date": "2025-04-01T09:00:00",
       "category": "expense",
       "content": "공과금",
       "amount": 30000
     },
     {
-      "id": "2",
+      "id": 2,
       "date": "2025-04-05T14:00:00",
       "category": "expense",
       "content": "구독",
       "amount": 14500
     },
     {
-      "id": "3",
+      "id": 3,
       "date": "2025-04-10T12:00:00",
       "category": "expense",
       "content": "통신비",
       "amount": 35000
     },
     {
-      "id": "4",
+      "id": 4,
       "date": "2025-04-15T00:00:00",
       "category": "expense",
       "content": "보험료",

--- a/money_log/src/components/BaseHeader.vue
+++ b/money_log/src/components/BaseHeader.vue
@@ -1,26 +1,26 @@
 <template>
   <div class="nav-wrapper">
-    <!-- 뒤로가기(왼쪽) -->
     <img
+      v-if="showBack"
       src="@/assets/images/back.png"
       alt="뒤로가기"
       class="nav-button"
       @click="goBack"
     />
-
-    <!-- 홈,설정(오른쪽) -->
     <div class="right-buttons">
       <img
+        v-if="showHome"
         src="@/assets/images/home.png"
         alt="홈"
         class="nav-button"
         @click="goHome"
       />
       <img
+        v-if="showSettings"
         src="@/assets/images/setting.png"
         alt="설정"
         class="nav-button"
-        @click="goSettings"
+        @click="emit('openSettings')"
       />
     </div>
   </div>
@@ -29,37 +29,37 @@
 <script setup>
 import { useRouter } from "vue-router";
 
+const emit = defineEmits(["openSettings"]);
 const router = useRouter();
 
-const goBack = () => {
-  router.back();
-};
+defineProps({
+  showBack: { type: Boolean, default: true },
+  showHome: { type: Boolean, default: true },
+  showSettings: { type: Boolean, default: true },
+});
 
-const goHome = () => {
-  router.push("/");
-};
-
-const goSettings = () => {
-  //설정 페이지
-};
+const goBack = () => router.back();
+const goHome = () => router.push("/");
 </script>
 
 <style scoped>
 .nav-wrapper {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px;
+  position: relative;
+  width: 100%;
+  height: 40px;
 }
 
 .right-buttons {
+  position: absolute;
+  top: -25px;
+  right: 25px;
   display: flex;
   gap: 12px;
 }
 
 .nav-button {
-  width: 1.2rem;
-  height: 1.2rem;
+  width: 20px;
+  height: 20px;
   cursor: pointer;
 }
 </style>

--- a/money_log/src/components/DailyMoneyLog/DailyMoneyLog.vue
+++ b/money_log/src/components/DailyMoneyLog/DailyMoneyLog.vue
@@ -27,7 +27,7 @@ const handleStartClick = () => {
   max-width: 362px;
   min-width: 362px;
   height: 130px;
-  margin: 28px auto 16px auto;
+  margin: 5px auto 16px auto;
   box-sizing: border-box;
 }
 

--- a/money_log/src/components/SettingPanel.vue
+++ b/money_log/src/components/SettingPanel.vue
@@ -1,0 +1,81 @@
+<!-- components/SettingPanel.vue -->
+<template>
+  <div class="settings-overlay" @click.self="$emit('close')">
+    <div class="settings-panel">
+      <h2 class="settings-title">Setting Log</h2>
+      <div class="setting-item" @click="goToProfileEdit">
+        <span class="icon">⚙️</span>
+        <span class="label">프로필 설정</span>
+        <span class="arrow">&gt;</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useRouter } from "vue-router";
+const router = useRouter();
+
+const goToProfileEdit = () => {
+  router.push("/UserProfileEdit");
+};
+</script>
+
+<style scoped>
+.settings-overlay {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(74, 71, 71, 0.6);
+  z-index: 1000;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.settings-panel {
+  background-color: white;
+  width: 70%;
+  max-width: 402px;
+  height: 100%;
+  padding: 24px 16px;
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-title {
+  font-size: 23px;
+  font-weight: bold;
+  color: #0b570e;
+  margin-bottom: 24px;
+}
+
+.setting-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #dedcdc;
+  padding: 12px 0;
+  cursor: pointer;
+}
+
+.setting-item .icon {
+  font-size: 18px;
+  margin-right: 8px;
+}
+
+.setting-item .label {
+  flex-grow: 1;
+  color: #0b570e;
+  font-weight: 600;
+  font-size: 19px;
+}
+
+.setting-item .arrow {
+  font-size: 18px;
+  color: #aaa;
+}
+</style>

--- a/money_log/src/pages/MainPage.vue
+++ b/money_log/src/pages/MainPage.vue
@@ -1,36 +1,38 @@
 <script setup>
-import { ref, onMounted } from 'vue';
-import { useRouter } from 'vue-router'; // ✅ 추가
-import DailyMoneyLog from '@/components/DailyMoneyLog/DailyMoneyLog.vue';
-import CustomCalendar from '@/components/CustomCalendar.vue';
-import MonthlySummary from '@/components/MonthlySummary.vue';
-import AddMoney from '@/pages/AddMoney.vue';
-import axios from 'axios';
+import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import DailyMoneyLog from "@/components/DailyMoneyLog/DailyMoneyLog.vue";
+import CustomCalendar from "@/components/CustomCalendar.vue";
+import MonthlySummary from "@/components/MonthlySummary.vue";
+import AddMoney from "@/pages/AddMoney.vue";
+import BaseHeader from "@/components/BaseHeader.vue";
+import SettingPanel from "@/components/SettingPanel.vue";
+import axios from "axios";
 
-const nickname = ref('Nickname');
+const nickname = ref("Nickname");
 const isModalOpen = ref(false);
 const isSettingsOpen = ref(false);
-const router = useRouter(); // ✅ 라우터 인스턴스 생성
+const router = useRouter();
 
 onMounted(async () => {
   try {
     // localStorage에서 userId 가져오기
-    const userId = localStorage.getItem('userId');
+    const userId = localStorage.getItem("userId");
 
     // userId가 없으면 Guest로 설정하고 API 호출 건너뛰기
     if (!userId) {
-      console.log('사용자 ID가 없습니다. Guest로 설정합니다.');
-      nickname.value = 'Guest';
+      console.log("사용자 ID가 없습니다. Guest로 설정합니다.");
+      nickname.value = "Guest";
       return;
     }
 
     // API 호출하여 닉네임 가져오기
     const response = await axios.get(`http://localhost:3000/user/${userId}`);
     nickname.value = response.data.nickname;
-    localStorage.setItem('nickname', response.data.nickname);
+    localStorage.setItem("nickname", response.data.nickname);
   } catch (error) {
-    console.error('닉네임 가져오기 실패:', error);
-    nickname.value = 'Guest'; // 에러 발생 시 기본값 설정
+    console.error("닉네임 가져오기 실패:", error);
+    nickname.value = "Guest"; // 에러 발생 시 기본값 설정
   }
 });
 
@@ -48,42 +50,34 @@ const closeSettings = () => {
   isSettingsOpen.value = false;
 };
 
-// ✅ 프로필 설정 페이지 이동
 const goToProfileEdit = () => {
-  router.push('/UserProfileEdit');
+  router.push("/UserProfileEdit");
 };
 </script>
 
 <template>
   <div class="main-page">
+    <BaseHeader
+      :showBack="false"
+      :showHome="false"
+      :showSettings="true"
+      @openSettings="
+        () => {
+          console.log('열기!');
+          openSettings();
+        }
+      "
+    />
+
     <div class="nickname-header">
       <div class="nickname-title">{{ nickname }}'s Log</div>
-      <img
-        src="@/assets/images/setting.png"
-        alt="설정"
-        class="settings-icon"
-        @click="openSettings"
-      />
     </div>
 
     <DailyMoneyLog @start="openAddMoneyModal" />
     <CustomCalendar />
     <MonthlySummary />
     <AddMoney :show="isModalOpen" @close="closeAddMoneyModal" />
-    <div
-      v-if="isSettingsOpen"
-      class="settings-overlay"
-      @click.self="closeSettings"
-    >
-      <div class="settings-panel">
-        <h2 class="settings-title">Setting Log</h2>
-        <div class="setting-item" @click="goToProfileEdit">
-          <span class="icon">⚙️</span>
-          <span class="label">프로필 설정</span>
-          <span class="arrow">&gt;</span>
-        </div>
-      </div>
-    </div>
+    <SettingPanel v-if="isSettingsOpen" @close="isSettingsOpen = false" />
   </div>
 </template>
 
@@ -110,11 +104,12 @@ const goToProfileEdit = () => {
 }
 
 .nickname-title {
-  font-size: 25px;
+  font-size: 26px;
   font-weight: bold;
   color: #0b570e;
   text-align: center;
-  margin-top: 15px;
+  margin-top: -40px;
+  margin-bottom: 4px;
 }
 
 .settings-icon {

--- a/money_log/src/pages/SpendingPage.vue
+++ b/money_log/src/pages/SpendingPage.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="main-layout">
-    <BaseHeader />
+    <BaseHeader
+      :showBack="true"
+      :showHome="false"
+      :showSettings="true"
+      @openSettings="openSettings"
+    />
     <h1 class="main-title">Spending Log</h1>
     <div class="log-card">
       <div class="chart-wrapper">
@@ -41,7 +46,7 @@
                 class="amount"
                 :class="log.category === 'income' ? 'income' : 'expense'"
               >
-                {{ log.category === 'income' ? '+' : '-' }}
+                {{ log.category === "income" ? "+" : "-" }}
                 {{ log.amount.toLocaleString() }}
               </span>
             </li>
@@ -49,17 +54,19 @@
         </div>
       </div>
     </div>
+    <SettingPanel v-if="isSettingsOpen" @close="isSettingsOpen = false" />
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
-import { Doughnut } from 'vue-chartjs';
-import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
-import { useMoneyStore } from '../stores/money';
-import { storeToRefs } from 'pinia';
-import BaseHeader from '@/components/BaseHeader.vue';
-import { useRouter } from 'vue-router';
+import { ref, computed, onMounted } from "vue";
+import { Doughnut } from "vue-chartjs";
+import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
+import { useMoneyStore } from "../stores/money";
+import { storeToRefs } from "pinia";
+import BaseHeader from "@/components/BaseHeader.vue";
+import SettingPanel from "@/components/SettingPanel.vue";
+import { useRouter } from "vue-router";
 
 ChartJS.register(ArcElement);
 
@@ -71,6 +78,9 @@ const income = ref(0);
 const expense = ref(0);
 const net = ref(0);
 const months = ref(0);
+
+const isSettingsOpen = ref(false);
+const openSettings = () => (isSettingsOpen.value = true);
 
 onMounted(async () => {
   await store.fetchMoneyLogs(); //데이터 불러오기
@@ -90,10 +100,10 @@ onMounted(async () => {
 const chartData = computed(() => ({
   datasets: [
     {
-      label: '이번 달 요약',
+      label: "이번 달 요약",
       data: [income.value, expense.value],
-      backgroundColor: ['#4D59FF', '#FF8548'],
-      borderColor: ['#4D59FF', '#FF8548'],
+      backgroundColor: ["#4D59FF", "#FF8548"],
+      borderColor: ["#4D59FF", "#FF8548"],
       borderWidth: 1,
     },
   ],
@@ -102,7 +112,7 @@ const chartData = computed(() => ({
 // 차트 옵션
 const chartOptions = {
   responsive: true,
-  cutout: '65%',
+  cutout: "65%",
 };
 
 ChartJS.register(ArcElement, Tooltip, Legend);
@@ -112,14 +122,18 @@ const DoughnutChart = Doughnut;
 const router = useRouter();
 
 const goDetail = () => {
-  router.push('/LogDetail');
+  router.push("/LogDetail");
 };
 </script>
+
 <style scoped>
 .main-layout {
   padding: 20px;
   background-color: #f1f1e8;
   margin: 0 auto;
+  position: relative;
+  overflow: hidden;
+  height: 100vh;
 }
 
 .main-title {
@@ -132,7 +146,7 @@ const goDetail = () => {
 .circle-header {
   font-size: 18px;
   font-weight: bold;
-  color: #228b22; /* 진한 초록 */
+  color: #228b22;
   margin-bottom: 10px;
 }
 
@@ -198,7 +212,7 @@ const goDetail = () => {
   background-color: #ffffff;
   padding: 12px;
   width: 100%;
-  font-family: 'Pretendard', sans-serif;
+  font-family: "Pretendard", sans-serif;
   background-color: #f1f1e8;
 }
 
@@ -259,7 +273,7 @@ ul {
 }
 
 .log-item:last-child {
-  border-bottom: none; /* 마지막 줄에는 선 없게 */
+  border-bottom: none;
 }
 
 .date {
@@ -280,5 +294,14 @@ ul {
   min-width: 75px;
   text-align: right;
   font-weight: 600;
+}
+
+::v-deep(.nav-wrapper) {
+  margin-top: 16px;
+}
+
+::v-deep(.right-buttons) {
+  top: 0 !important;
+  right: 20px !important;
 }
 </style>


### PR DESCRIPTION
## 🔗 반영 브랜치
(#49) feat/Setting -> dev

## 📝 작업 내용
- `Spending.vue`에 `BaseHeader` 설정 아이콘 기능 연동
- 설정 패널(`SettingPanel`) 컴포넌트 적용 및 조건부 렌더링 추가
- 설정 아이콘 클릭 시 패널이 화면 전체를 가리지 않도록 높이 및 위치 조정
- `Spending.vue`에서 홈 버튼 비활성화 (`BaseHeader`에 `:showHome="false"` 적용)
- 설정 아이콘 위치 MainPage 기준으로 맞춤

### 📸 스크린샷 (선택)
> `Spending` 실행 화면
![스크린샷 2025-04-10 오후 2 12 33](https://github.com/user-attachments/assets/055d833c-3d3c-4a6e-a89c-704b7d97e0d9)

![스크린샷 2025-04-10 오후 2 12 50](https://github.com/user-attachments/assets/3a919fa4-9689-4c79-a713-69765ea3db52)

## 💬 리뷰 요구사항(선택)
- /money 페이지 상단바도 바로 작업 들어가겠습니다